### PR TITLE
Add DB setup and simple chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # PROJETOIA
  
 ESTE PROEJETO TEM COMO OBJETIVO DISPONIBILIZAR UM ALGORITMO SIMPLES, FOCADO NO APRENDIZADO DE IA PARA ALUNOS, ESTUDANTES DE INFORMÁTICA INDEPENDENTE DO NÍVEL. SERÁ DISPONIBILIZADO ONLINE ATRAVÉS DO GIT, E SEUS RESULTADOS MAPEADOS PARA ESTUDOS FUTUROS.
+## Banco de dados
+
+Execute o script `create_database.sql` em seu servidor MySQL para criar o banco `alimentaia` e as tabelas utilizadas pela aplicação.
+
+```
+mysql -u root -p < create_database.sql
+```
+
+## Chatbot
+
+Um chatbot simples em Python está disponível no arquivo `chatbot.py`. Ele responde perguntas sobre o planejamento de aulas gravado na tabela `planejamento` do banco de dados.
+
+Instale a dependência `mysql-connector-python` e execute o script:
+
+```
+pip install mysql-connector-python
+python3 chatbot.py
+```
+
+Digite `sair` para encerrar a conversa.
+

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,63 @@
+import mysql.connector
+from datetime import datetime
+
+DB_CONFIG = {
+    'host': 'localhost',
+    'user': 'root',
+    'password': '',
+    'database': 'alimentaia'
+}
+
+HELP_MSG = (
+    "Digite uma pergunta sobre o planejamento das aulas.\n"
+    "Por exemplo: 'Qual o planejamento de Matemática?'\n"
+    "Digite 'sair' para encerrar."
+)
+
+def buscar_planejamento(disciplina: str):
+    """Recupera do banco os planejamentos da disciplina informada."""
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cur = conn.cursor(dictionary=True)
+    query = ("SELECT data, conteudo FROM planejamento "
+             "WHERE disciplina LIKE %s ORDER BY data")
+    cur.execute(query, (f"%{disciplina}%",))
+    resultados = cur.fetchall()
+    cur.close()
+    conn.close()
+    return resultados
+
+def responder_pergunta(pergunta: str):
+    pergunta_lower = pergunta.lower()
+    if 'planejamento' in pergunta_lower or 'aula' in pergunta_lower:
+        palavras = pergunta_lower.split()
+        disciplina = None
+        for palavra in palavras:
+            if palavra in {'matemática', 'português', 'informática'}:
+                disciplina = palavra
+                break
+        if not disciplina:
+            disciplina = input('Sobre qual disciplina? ').strip().lower()
+        planos = buscar_planejamento(disciplina)
+        if not planos:
+            return 'Nenhum planejamento encontrado.'
+        linhas = [
+            f"{datetime.strptime(str(p['data']), '%Y-%m-%d').strftime('%d/%m/%Y')}: {p['conteudo']}"
+            for p in planos
+        ]
+        return '\n'.join(linhas)
+    return 'Desculpe, não entendi a pergunta.'
+
+def main():
+    print('Chatbot do Planejamento de Aulas')
+    print(HELP_MSG)
+    while True:
+        pergunta = input('Você: ').strip()
+        if pergunta.lower() in {'sair', 'exit', 'quit'}:
+            print('Chatbot: Até logo!')
+            break
+        resposta = responder_pergunta(pergunta)
+        print('Chatbot:', resposta)
+
+if __name__ == '__main__':
+    main()
+

--- a/create_database.sql
+++ b/create_database.sql
@@ -1,0 +1,20 @@
+-- Cria o banco de dados e as tabelas utilizadas pela aplicação
+CREATE DATABASE IF NOT EXISTS alimentaia DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE alimentaia;
+
+-- Tabela utilizada para armazenar as informações enviadas pelo formulário
+CREATE TABLE IF NOT EXISTS dados (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    Disciplina VARCHAR(100) NOT NULL,
+    Nota DECIMAL(5,2),
+    Hora TIME,
+    nome VARCHAR(100) NOT NULL
+);
+
+-- Tabela opcional para registrar o planejamento das aulas
+CREATE TABLE IF NOT EXISTS planejamento (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    disciplina VARCHAR(100) NOT NULL,
+    data DATE NOT NULL,
+    conteudo TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- add SQL script for creating the MySQL database
- implement a simple Python chatbot that reads the planning table
- document setup and chatbot usage in README

## Testing
- `python3 -m py_compile chatbot.py`
- `php -l php/conectabanco.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68411995ee888330a4d4c684abba9b0f