### PR TITLE
Add Bootstrap index and simple web chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ python3 chatbot.py
 
 Digite `sair` para encerrar a conversa.
 
+
+## Interface Web
+
+O projeto possui agora uma página inicial `index.html` criada com Bootstrap. Ela permite acessar duas funcionalidades principais:
+
+- **Alimentar IA**: formário disponível em `alimento.php` para registrar novos dados no banco.
+- **Chatbot**: interface web em `chatbot.php` para consultar o planejamento de aulas diretamente pelo navegador.
+
+Basta abrir `index.html` em um servidor PHP para utilizar a aplicação.

--- a/chatbot.php
+++ b/chatbot.php
@@ -1,0 +1,94 @@
+<?php
+require_once __DIR__.'/php/conectabanco.php';
+
+$resposta = '';
+$pergunta = '';
+$disciplina_extra = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $pergunta = trim($_POST['pergunta'] ?? '');
+    $disciplina_extra = trim($_POST['disciplina_extra'] ?? '');
+    if ($pergunta !== '') {
+        $pergunta_lower = mb_strtolower($pergunta, 'UTF-8');
+        if (str_contains($pergunta_lower, 'planejamento') || str_contains($pergunta_lower, 'aula')) {
+            $disciplinas = ['matemática', 'português', 'informática'];
+            $disciplina = null;
+            foreach ($disciplinas as $d) {
+                if (str_contains($pergunta_lower, $d)) {
+                    $disciplina = $d;
+                    break;
+                }
+            }
+            if (!$disciplina) {
+                $disciplina = mb_strtolower($disciplina_extra, 'UTF-8');
+            }
+            if ($disciplina) {
+                try {
+                    $pdo = new PDO($dsn, $user, $pass, $options);
+                    $stmt = $pdo->prepare('SELECT data, conteudo FROM planejamento WHERE disciplina LIKE ? ORDER BY data');
+                    $stmt->execute(["%$disciplina%"]);
+                    $planos = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                    if (!$planos) {
+                        $resposta = 'Nenhum planejamento encontrado.';
+                    } else {
+                        $linhas = [];
+                        foreach ($planos as $p) {
+                            $linhas[] = date('d/m/Y', strtotime($p['data'])) . ': ' . $p['conteudo'];
+                        }
+                        $resposta = implode('<br>', $linhas);
+                    }
+                } catch (PDOException $e) {
+                    $resposta = 'Erro ao acessar o banco de dados.';
+                }
+            } else {
+                $resposta = 'Por favor, informe a disciplina.';
+            }
+        } else {
+            $resposta = 'Desculpe, não entendi a pergunta.';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Chatbot - Projeto IA Notas</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light d-flex flex-column min-vh-100">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container">
+            <a class="navbar-brand" href="index.html">Projeto IA Notas</a>
+        </div>
+    </nav>
+    <main class="container flex-fill py-5">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <h2 class="mb-4 text-center">Chatbot do Planejamento</h2>
+                <form method="POST" class="mb-3">
+                    <div class="mb-3">
+                        <label for="pergunta" class="form-label">Pergunta</label>
+                        <input type="text" class="form-control" id="pergunta" name="pergunta" value="<?php echo htmlspecialchars($pergunta); ?>" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="disciplina_extra" class="form-label">Disciplina (opcional)</label>
+                        <input type="text" class="form-control" id="disciplina_extra" name="disciplina_extra" value="<?php echo htmlspecialchars($disciplina_extra); ?>" placeholder="Matemática, Português ou Informática">
+                    </div>
+                    <button type="submit" class="btn btn-primary">Enviar</button>
+                </form>
+                <?php if ($resposta !== ''): ?>
+                    <div class="alert alert-secondary" role="alert">
+                        <?php echo $resposta; ?>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </main>
+    <footer class="bg-body-secondary text-center py-3 mt-auto">
+        <small>Projeto IA Notas</small>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Projeto IA Notas</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light d-flex flex-column min-vh-100">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container">
+            <a class="navbar-brand" href="#">Projeto IA Notas</a>
+        </div>
+    </nav>
+    <main class="container flex-fill py-5">
+        <div class="row justify-content-center text-center">
+            <div class="col-md-8">
+                <h1 class="mb-4">Bem-vindo</h1>
+                <p class="lead">Escolha uma das opções abaixo para alimentar a IA com novos dados ou conversar com o chatbot sobre o planejamento de aulas.</p>
+                <div class="d-grid gap-3 d-sm-flex justify-content-sm-center">
+                    <a href="alimento.php" class="btn btn-success btn-lg">Alimentar IA</a>
+                    <a href="chatbot.php" class="btn btn-primary btn-lg">Abrir Chatbot</a>
+                </div>
+            </div>
+        </div>
+    </main>
+    <footer class="bg-body-secondary text-center py-3 mt-auto">
+        <small>Projeto IA Notas</small>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add responsive `index.html` linking to data form and chatbot
- create `chatbot.php` to provide web interface for answering questions from the database
- document new web interface in README

## Testing
- `python3 -m py_compile chatbot.py`
- `php -l chatbot.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411be98c0083308817d310f7512da9